### PR TITLE
disable image and picto icons in read-only mode

### DIFF
--- a/teammapper-frontend/src/app/modules/application/components/toolbar/toolbar.component.html
+++ b/teammapper-frontend/src/app/modules/application/components/toolbar/toolbar.component.html
@@ -180,6 +180,7 @@
   <ng-template #renderInput>
     <button
       (click)="imageUpload.click()"
+      [disabled]="editDisabled"
       class="label-file-upload mat-icon-button mat-primary mat-focus-indicator"
       mat-icon-button>
       <mat-icon>image</mat-icon>
@@ -196,6 +197,7 @@
     <button
       (click)="pictogram()"
       [title]="'TOOLTIPS.PICTOGRAM' | translate"
+      [disabled]="editDisabled"
       color="primary"
       mat-icon-button>
       <mat-icon>nature_people</mat-icon>


### PR DESCRIPTION
Closes [#700](https://github.com/b310-digital/teammapper/issues/700)