### PR TITLE
disable image and picto icons in read-only mode

### DIFF
--- a/teammapper-frontend/src/app/modules/application/components/toolbar/toolbar.component.html
+++ b/teammapper-frontend/src/app/modules/application/components/toolbar/toolbar.component.html
@@ -64,7 +64,10 @@
       <mat-icon>insert_drive_file</mat-icon>
       <span>{{ 'GENERAL.JSON' | translate }}</span>
     </button>
-    <button (click)="exportMap('mermaid')" mat-menu-item>
+    <button 
+      (click)="exportMap('mermaid')" 
+      [title]="'TOOLTIPS.EXPORT_MERMAID' | translate"
+      mat-menu-item>
       <mat-icon>edit_square</mat-icon>
       <span>{{ 'GENERAL.MERMAID' | translate }}</span>
     </button>

--- a/teammapper-frontend/src/app/modules/application/components/toolbar/toolbar.component.html
+++ b/teammapper-frontend/src/app/modules/application/components/toolbar/toolbar.component.html
@@ -190,6 +190,7 @@
   <ng-template #renderInput>
     <button
       (click)="imageUpload.click()"
+      [disabled]="editDisabled"
       class="label-file-upload mat-icon-button mat-primary mat-focus-indicator"
       mat-icon-button>
       <mat-icon>image</mat-icon>
@@ -206,6 +207,7 @@
     <button
       (click)="pictogram()"
       [title]="'TOOLTIPS.PICTOGRAM' | translate"
+      [disabled]="editDisabled"
       color="primary"
       mat-icon-button>
       <mat-icon>nature_people</mat-icon>

--- a/teammapper-frontend/src/app/modules/application/components/toolbar/toolbar.component.html
+++ b/teammapper-frontend/src/app/modules/application/components/toolbar/toolbar.component.html
@@ -21,7 +21,7 @@
     <button
       [ngClass]="{ 'mat-button-disabled': editDisabled }"
       (click)="upload.click()"
-      [title]="'TOOLTIPS.IMPORT_MAP' | translate"
+      [title]="'TOOLTIPS.IMPORT_JSON' | translate"
       color="primary"
       mat-menu-item>
       <mat-icon>insert_drive_file</mat-icon>
@@ -57,7 +57,10 @@
   </button>
 
   <mat-menu #export_map="matMenu">
-    <button (click)="exportMap('json')" mat-menu-item>
+    <button 
+      (click)="exportMap('json')"
+      [title]="'TOOLTIPS.EXPORT_JSON' | translate"
+      mat-menu-item>
       <mat-icon>insert_drive_file</mat-icon>
       <span>{{ 'GENERAL.JSON' | translate }}</span>
     </button>
@@ -65,19 +68,31 @@
       <mat-icon>edit_square</mat-icon>
       <span>{{ 'GENERAL.MERMAID' | translate }}</span>
     </button>
-    <button (click)="exportMap('svg')" mat-menu-item>
+    <button 
+      (click)="exportMap('svg')"
+      [title]="'TOOLTIPS.EXPORT_SVG' | translate"
+      mat-menu-item>
       <mat-icon>image</mat-icon>
       <span>{{ 'GENERAL.SVG' | translate }}</span>
     </button>
-    <button (click)="exportMap('png')" mat-menu-item>
+    <button 
+      (click)="exportMap('png')"
+      [title]="'TOOLTIPS.EXPORT_PNG' | translate"
+      mat-menu-item>
       <mat-icon>image</mat-icon>
       <span>{{ 'GENERAL.PNG' | translate }}</span>
     </button>
-    <button (click)="exportMap('jpeg')" mat-menu-item>
+    <button 
+      (click)="exportMap('jpeg')"
+      [title]="'TOOLTIPS.EXPORT_JPEG' | translate"
+      mat-menu-item>
       <mat-icon>image</mat-icon>
       <span>{{ 'GENERAL.JPG' | translate }}</span>
     </button>
-    <button (click)="exportMap('pdf')" mat-menu-item>
+    <button 
+      (click)="exportMap('pdf')"
+      [title]="'TOOLTIPS.EXPORT_PDF' | translate"
+      mat-menu-item>
       <mat-icon>picture_as_pdf</mat-icon>
       <span>{{ 'GENERAL.PDF' | translate }}</span>
     </button>
@@ -180,7 +195,7 @@
   <ng-template #renderRemove>
     <button
       (click)="mmpService.removeNodeImage()"
-      [title]="'TOOLTIPS.NODE_IMAGE' | translate"
+      [title]="'TOOLTIPS.NODE_IMAGE_REMOVE' | translate"
       [disabled]="editDisabled"
       color="primary"
       mat-icon-button>
@@ -190,6 +205,7 @@
   <ng-template #renderInput>
     <button
       (click)="imageUpload.click()"
+      [title]="'TOOLTIPS.NODE_IMAGE' | translate"
       [disabled]="editDisabled"
       class="label-file-upload mat-icon-button mat-primary mat-focus-indicator"
       mat-icon-button>
@@ -263,15 +279,26 @@
 
   <span class="toolbar-spacer"></span>
 
-  <button color="primary" mat-icon-button routerLink="/app/shortcuts">
+  <button 
+    color="primary"
+    [title]="'TOOLTIPS.SHORTCUTS' | translate"
+    mat-icon-button routerLink="/app/shortcuts">
     <mat-icon>shortcuts</mat-icon>
   </button>
 
-  <button color="primary" mat-icon-button routerLink="/app/settings">
+  <button 
+    color="primary" 
+    [title]="'TOOLTIPS.SETTINGS' | translate"
+    mat-icon-button 
+    routerLink="/app/settings">
     <mat-icon>settings</mat-icon>
   </button>
 
-  <button color="primary" (click)="openAbout()" mat-icon-button>
+  <button 
+    color="primary" 
+    (click)="openAbout()" 
+    [title]="'TOOLTIPS.INFO' | translate"
+    mat-icon-button>
     <mat-icon>info</mat-icon>
   </button>
 </mat-toolbar>

--- a/teammapper-frontend/src/assets/i18n/de.json
+++ b/teammapper-frontend/src/assets/i18n/de.json
@@ -12,7 +12,13 @@
   "TOOLTIPS": {
     "IMPORT_MAP": "Mindmap importieren",
     "IMPORT_MERMAID": "Mermaid Mindmap importieren",
+    "IMPORT_JSON": "JSON Mindmap importieren",
     "EXPORT_MAP": "Mindmap exportieren",
+    "EXPORT_JSON": "Mindmap als JSON exportieren",
+    "EXPORT_SVG": "Mindmap als SVG exportieren",
+    "EXPORT_PNG": "Mindmap als PNG exportieren",
+    "EXPORT_JPEG": "Mindmap als JPEG exportieren",
+    "EXPORT_PDF": "Mindmap als PDF exportieren",
     "ESC": "Dialog schließen",
     "FULLSCREEN": "Vollbild",
     "CLOSE_MENU": "Seitenmenü öffnen",
@@ -37,7 +43,8 @@
     "SELECT_NODE_ABOVE": "Knoten oben auswählen",
     "EDIT_NODE": "Änderungen am Text eines Knotens erlauben",
     "COUPLE_NODE": "Knoten koppeln oder entkoppeln",
-    "NODE_IMAGE": "Bild zum Knoten hinzufügen oder entfernen",
+    "NODE_IMAGE": "Bild zum Knoten hinzufügen",
+    "NODE_IMAGE_REMOVE": "Bild vom Knoten entfernen",
     "PICTOGRAM": "Piktrogramm",
     "BOLD_TEXT": "Fett",
     "ITALIC_TEXT": "Kursiv",
@@ -71,7 +78,8 @@
     "FONT_INCREMENT": "Schrittgröße bei Einstellung Schriftgröße",
     "FONT_INCREASE": "Schrift vergrößern",
     "FONT_DECREASE": "Schrift verkleinern",
-    "SHOW_LINKTEXT": "Linktext statt Icon anzeigen"
+    "SHOW_LINKTEXT": "Linktext statt Icon anzeigen",
+    "INFO": "Info Screen öffnen"
   },
   "MODALS": {
     "GENERAL": {

--- a/teammapper-frontend/src/assets/i18n/de.json
+++ b/teammapper-frontend/src/assets/i18n/de.json
@@ -15,6 +15,7 @@
     "IMPORT_JSON": "JSON Mindmap importieren",
     "EXPORT_MAP": "Mindmap exportieren",
     "EXPORT_JSON": "Mindmap als JSON exportieren",
+    "EXPORT_MERMAID": "Mindmap als Mermaid exportieren",
     "EXPORT_SVG": "Mindmap als SVG exportieren",
     "EXPORT_PNG": "Mindmap als PNG exportieren",
     "EXPORT_JPEG": "Mindmap als JPEG exportieren",

--- a/teammapper-frontend/src/assets/i18n/en.json
+++ b/teammapper-frontend/src/assets/i18n/en.json
@@ -15,6 +15,7 @@
     "IMPORT_JSON": "Imports a JSON Mindmap",
     "EXPORT_MAP": "Exports the map",
     "EXPORT_JSON": "Exports the map as JSON",
+    "EXPORT_MERMAID": "Exports the map as Mermaid",
     "EXPORT_SVG": "Exports the map as SVG",
     "EXPORT_PNG": "Exports the map as PNG",
     "EXPORT_JPEG": "Exports the map as JPEG",

--- a/teammapper-frontend/src/assets/i18n/en.json
+++ b/teammapper-frontend/src/assets/i18n/en.json
@@ -44,7 +44,7 @@
     "EDIT_NODE": "Allows to edit the text of the node",
     "COUPLE_NODE": "Groups or ungroups the node",
     "NODE_IMAGE": "Adds an image to the node",
-    "NODE_IMAGE_REMOVE": "Removes an image to the node",
+    "NODE_IMAGE_REMOVE": "Removes an image from the node",
     "PICTOGRAM": "Pictrogram",
     "BOLD_TEXT": "Changes the weight of the text",
     "ITALIC_TEXT": "Changes the style of the text",

--- a/teammapper-frontend/src/assets/i18n/en.json
+++ b/teammapper-frontend/src/assets/i18n/en.json
@@ -12,7 +12,13 @@
   "TOOLTIPS": {
     "IMPORT_MAP": "Imports the map",
     "IMPORT_MERMAID": "Imports a Mermaid Mindmap",
+    "IMPORT_JSON": "Imports a JSON Mindmap",
     "EXPORT_MAP": "Exports the map",
+    "EXPORT_JSON": "Exports the map as JSON",
+    "EXPORT_SVG": "Exports the map as SVG",
+    "EXPORT_PNG": "Exports the map as PNG",
+    "EXPORT_JPEG": "Exports the map as JPEG",
+    "EXPORT_PDF": "Exports the map as PDF",
     "ESC": "Closes the dialog window",
     "FULLSCREEN": "Sets the full screen",
     "CLOSE_MENU": "Closes the side menu",
@@ -38,6 +44,7 @@
     "EDIT_NODE": "Allows to edit the text of the node",
     "COUPLE_NODE": "Groups or ungroups the node",
     "NODE_IMAGE": "Adds an image to the node",
+    "NODE_IMAGE_REMOVE": "Removes an image to the node",
     "PICTOGRAM": "Pictrogram",
     "BOLD_TEXT": "Changes the weight of the text",
     "ITALIC_TEXT": "Changes the style of the text",
@@ -71,7 +78,8 @@
     "FONT_INCREMENT": "Font size step",
     "FONT_INCREASE": "Increase font ",
     "FONT_DECREASE": "Decrease font",
-    "SHOW_LINKTEXT": "Show the linktext instead of the link icon"
+    "SHOW_LINKTEXT": "Show the linktext instead of the link icon",
+    "INFO": "Opens the info screen"
   },
   "MODALS": {
     "GENERAL": {

--- a/teammapper-frontend/src/assets/i18n/es.json
+++ b/teammapper-frontend/src/assets/i18n/es.json
@@ -15,6 +15,7 @@
     "IMPORT_JSON": "Importa un mapa mental en formato JSON",
     "EXPORT_MAP": "Exporta el mapa",
     "EXPORT_JSON": "Exporta el mapa como JSON",
+    "EXPORT_MERMAID": "Exporta el mapa como Mermaid", 
     "EXPORT_SVG": "Exporta el mapa como SVG",
     "EXPORT_PNG": "Exporta el mapa como PNG",
     "EXPORT_JPEG": "Exporta el mapa como JPEG",

--- a/teammapper-frontend/src/assets/i18n/es.json
+++ b/teammapper-frontend/src/assets/i18n/es.json
@@ -10,9 +10,15 @@
     "DE": "Alemán"
   },
   "TOOLTIPS": {
-    "IMPORT_MAP": "Imports the map",
-    "IMPORT_MERMAID": "Imports a Mermaid Mindmap",
-    "EXPORT_MAP": "Exports the map",
+    "IMPORT_MAP": "Importa el mapa",
+    "IMPORT_MERMAID": "Importa un mapa mental de Mermaid",
+    "IMPORT_JSON": "Importa un mapa mental en formato JSON",
+    "EXPORT_MAP": "Exporta el mapa",
+    "EXPORT_JSON": "Exporta el mapa como JSON",
+    "EXPORT_SVG": "Exporta el mapa como SVG",
+    "EXPORT_PNG": "Exporta el mapa como PNG",
+    "EXPORT_JPEG": "Exporta el mapa como JPEG",
+    "EXPORT_PDF": "Exporta el mapa como PDF",
     "ESC": "Cerrar el cuadro de diálogo",
     "FULLSCREEN": "A pantalla completa",
     "CLOSE_MENU": "Cerrar el menú lateral",
@@ -38,6 +44,7 @@
     "EDIT_NODE": "Permitir editar el texto del nodo",
     "COUPLE_NODE": "Bloquear o desbloquear el nodo",
     "NODE_IMAGE": "Añadir una imagen al nodo",
+    "NODE_IMAGE_REMOVE": "Elimina una imagen del nodo",
     "PICTOGRAM": "Pictrogram",
     "BOLD_TEXT": "Cambiar la importancia del texto",
     "ITALIC_TEXT": "Cambiar el estilo del texto",
@@ -70,7 +77,8 @@
     "FONT_MAX_SIZE": "Maximal font size",
     "FONT_INCREMENT": "Font size step",
     "FONT_INCREASE": "Increase font ",
-    "FONT_DECREASE": "Decrease font"
+    "FONT_DECREASE": "Decrease font",
+    "INFO": "Abre la pantalla de información"
   },
   "MODALS": {
     "GENERAL": {

--- a/teammapper-frontend/src/assets/i18n/fr.json
+++ b/teammapper-frontend/src/assets/i18n/fr.json
@@ -10,9 +10,15 @@
     "DE": "Allemand"
   },
   "TOOLTIPS": {
-    "IMPORT_MAP": "Imports the map",
-    "IMPORT_MERMAID": "Imports a Mermaid Mindmap",
-    "EXPORT_MAP": "Exports the map",
+    "IMPORT_MAP": "Importe la carte",
+    "IMPORT_MERMAID": "Importe une carte mentale Mermaid",
+    "IMPORT_JSON": "Importe une carte mentale en JSON",
+    "EXPORT_MAP": "Exporte la carte",
+    "EXPORT_JSON": "Exporte la carte au format JSON",
+    "EXPORT_SVG": "Exporte la carte au format SVG",
+    "EXPORT_PNG": "Exporte la carte au format PNG",
+    "EXPORT_JPEG": "Exporte la carte au format JPEG",
+    "EXPORT_PDF": "Exporte la carte au format PDF",
     "ESC": "Ferme la fenêtre de dialogue",
     "FULLSCREEN": "Mettre en plein écran",
     "CLOSE_MENU": "Ferme le menu latéral",
@@ -38,6 +44,7 @@
     "EDIT_NODE": "Allows to edit the text of the node",
     "COUPLE_NODE": "Verrouille ou déverrouille le nœud",
     "NODE_IMAGE": "Ajoute une image au noeud",
+    "NODE_IMAGE_REMOVE": "Supprime une image du nœud",
     "PICTOGRAM": "Pictrogram",
     "START_EDIT_NODE": "Edit node text",
     "BOLD_TEXT": "Change la taille du texte",
@@ -70,7 +77,8 @@
     "FONT_MAX_SIZE": "Maximal font size",
     "FONT_INCREMENT": "Font size step",
     "FONT_INCREASE": "Increase font ",
-    "FONT_DECREASE": "Decrease font"
+    "FONT_DECREASE": "Decrease font",
+    "INFO": "Ouvre l’écran d’informations"
   },
   "MODALS": {
     "GENERAL": {

--- a/teammapper-frontend/src/assets/i18n/fr.json
+++ b/teammapper-frontend/src/assets/i18n/fr.json
@@ -15,6 +15,7 @@
     "IMPORT_JSON": "Importe une carte mentale en JSON",
     "EXPORT_MAP": "Exporte la carte",
     "EXPORT_JSON": "Exporte la carte au format JSON",
+    "EXPORT_MERMAID": "Exporte la carte au format Mermaid", 
     "EXPORT_SVG": "Exporte la carte au format SVG",
     "EXPORT_PNG": "Exporte la carte au format PNG",
     "EXPORT_JPEG": "Exporte la carte au format JPEG",

--- a/teammapper-frontend/src/assets/i18n/it.json
+++ b/teammapper-frontend/src/assets/i18n/it.json
@@ -12,7 +12,13 @@
   "TOOLTIPS": {
     "IMPORT_MAP": "Importa mappa",
     "IMPORT_MERMAID": "Importa una mappa mentale Mermaid",
+    "IMPORT_JSON": "Importa una mappa mentale in formato JSON",
     "EXPORT_MAP": "Esporta mappa",
+    "EXPORT_JSON": "Esporta la mappa come JSON",
+    "EXPORT_SVG": "Esporta la mappa come SVG",
+    "EXPORT_PNG": "Esporta la mappa come PNG",
+    "EXPORT_JPEG": "Esporta la mappa come JPEG",
+    "EXPORT_PDF": "Esporta la mappa come PDF",
     "ESC": "Chiudi finestra di dialogo",
     "FULLSCREEN": "Imposta schermo intero",
     "CLOSE_MENU": "Chiudi menu' laterale",
@@ -38,6 +44,7 @@
     "EDIT_NODE": "Permetti di modificare il testo del nodo",
     "COUPLE_NODE": "Blocca o sblocca il nodo",
     "NODE_IMAGE": "Aggiungi un'immagine al nodo",
+    "NODE_IMAGE_REMOVE": "Rimuove un'immagine dal nodo",
     "PICTOGRAM": "Pittogramma",
     "START_EDIT_NODE": "Modifica il testo del nodo",
     "BOLD_TEXT": "Cambia la larghezza del testo",
@@ -70,7 +77,8 @@
     "FONT_MAX_SIZE": "Dimensione massima del font",
     "FONT_INCREMENT": "Dimensione passo del font",
     "FONT_INCREASE": "Aumenta font",
-    "FONT_DECREASE": "Diminuisci font"
+    "FONT_DECREASE": "Diminuisci font",
+    "INFO": "Apre la schermata delle informazioni"
   },
   "MODALS": {
     "GENERAL": {

--- a/teammapper-frontend/src/assets/i18n/it.json
+++ b/teammapper-frontend/src/assets/i18n/it.json
@@ -15,6 +15,7 @@
     "IMPORT_JSON": "Importa una mappa mentale in formato JSON",
     "EXPORT_MAP": "Esporta mappa",
     "EXPORT_JSON": "Esporta la mappa come JSON",
+    "EXPORT_MERMAID": "Esporta la mappa come Mermaid", 
     "EXPORT_SVG": "Esporta la mappa come SVG",
     "EXPORT_PNG": "Esporta la mappa come PNG",
     "EXPORT_JPEG": "Esporta la mappa come JPEG",

--- a/teammapper-frontend/src/assets/i18n/pt-br.json
+++ b/teammapper-frontend/src/assets/i18n/pt-br.json
@@ -10,9 +10,15 @@
     "DE": "Alemão"
   },
   "TOOLTIPS": {
-    "IMPORT_MAP": "Imports the map",
-    "IMPORT_MERMAID": "Imports a Mermaid Mindmap",
-    "EXPORT_MAP": "Exports the map",
+    "IMPORT_MAP": "Importa o mapa",
+    "IMPORT_MERMAID": "Importa um mapa mental do Mermaid",
+    "IMPORT_JSON": "Importa um mapa mental em JSON",
+    "EXPORT_MAP": "Exporta o mapa",
+    "EXPORT_JSON": "Exporta o mapa como JSON",
+    "EXPORT_SVG": "Exporta o mapa como SVG",
+    "EXPORT_PNG": "Exporta o mapa como PNG",
+    "EXPORT_JPEG": "Exporta o mapa como JPEG",
+    "EXPORT_PDF": "Exporta o mapa como PDF",
     "ESC": "Fechar a janela de diálogo",
     "FULLSCREEN": "Modo tela cheia",
     "CLOSE_MENU": "Fechar o menu lateral",
@@ -38,6 +44,7 @@
     "EDIT_NODE": "Permitir editar o texto do nó",
     "COUPLE_NODE": "Bloqueia ou desbloqueia o nó",
     "NODE_IMAGE": "Adiciona uma imagem ao nó",
+    "NODE_IMAGE_REMOVE": "Remove uma imagem do nó",
     "PICTOGRAM": "Pictrogram",
     "BOLD_TEXT": "Negrito",
     "ITALIC_TEXT": "Itálico",
@@ -70,7 +77,8 @@
     "FONT_MAX_SIZE": "Maximal font size",
     "FONT_INCREMENT": "Font size step",
     "FONT_INCREASE": "Increase font ",
-    "FONT_DECREASE": "Decrease font"
+    "FONT_DECREASE": "Decrease font",
+    "INFO": "Abre a tela de informações"
   },
   "MODALS": {
     "GENERAL": {

--- a/teammapper-frontend/src/assets/i18n/pt-br.json
+++ b/teammapper-frontend/src/assets/i18n/pt-br.json
@@ -15,6 +15,7 @@
     "IMPORT_JSON": "Importa um mapa mental em JSON",
     "EXPORT_MAP": "Exporta o mapa",
     "EXPORT_JSON": "Exporta o mapa como JSON",
+    "EXPORT_MERMAID": "Exporta o mapa como Mermaid", 
     "EXPORT_SVG": "Exporta o mapa como SVG",
     "EXPORT_PNG": "Exporta o mapa como PNG",
     "EXPORT_JPEG": "Exporta o mapa como JPEG",

--- a/teammapper-frontend/src/assets/i18n/zh-cn.json
+++ b/teammapper-frontend/src/assets/i18n/zh-cn.json
@@ -11,8 +11,14 @@
   },
   "TOOLTIPS": {
     "IMPORT_MAP": "导入思维导图",
-    "IMPORT_MERMAID": "Imports a Mermaid Mindmap",
+    "IMPORT_MERMAID": "导入Mermaid思维导图",
+    "IMPORT_JSON": "导入JSON思维导图",
     "EXPORT_MAP": "导出思维导图",
+    "EXPORT_JSON": "以JSON格式导出地图",
+    "EXPORT_SVG": "以SVG格式导出地图",
+    "EXPORT_PNG": "以PNG格式导出地图",
+    "EXPORT_JPEG": "以JPEG格式导出地图",
+    "EXPORT_PDF": "以PDF格式导出地图",
     "ESC": "关闭",
     "FULLSCREEN": "全屏",
     "CLOSE_MENU": "关闭菜单",
@@ -38,6 +44,7 @@
     "EDIT_NODE": "编辑节点",
     "COUPLE_NODE": "锁定节点",
     "NODE_IMAGE": "向节点添加图片",
+    "NODE_IMAGE_REMOVE": "从节点中移除图片",
     "PICTOGRAM": "图标",
     "BOLD_TEXT": "粗体",
     "ITALIC_TEXT": "斜体",
@@ -70,7 +77,8 @@
     "FONT_MAX_SIZE": "最大字体大小",
     "FONT_INCREMENT": "字体大小步长",
     "FONT_INCREASE": "增大字体",
-    "FONT_DECREASE": "减小字体"
+    "FONT_DECREASE": "减小字体",
+    "INFO": "打开信息界面"
   },
   "MODALS": {
     "GENERAL": {

--- a/teammapper-frontend/src/assets/i18n/zh-cn.json
+++ b/teammapper-frontend/src/assets/i18n/zh-cn.json
@@ -15,6 +15,7 @@
     "IMPORT_JSON": "导入JSON思维导图",
     "EXPORT_MAP": "导出思维导图",
     "EXPORT_JSON": "以JSON格式导出地图",
+    "EXPORT_MERMAID": "以Mermaid格式导出地图", 
     "EXPORT_SVG": "以SVG格式导出地图",
     "EXPORT_PNG": "以PNG格式导出地图",
     "EXPORT_JPEG": "以JPEG格式导出地图",

--- a/teammapper-frontend/src/assets/i18n/zh-tw.json
+++ b/teammapper-frontend/src/assets/i18n/zh-tw.json
@@ -10,9 +10,15 @@
     "DE": "德語"
   },
   "TOOLTIPS": {
-    "IMPORT_MAP": "Imports the map",
-    "IMPORT_MERMAID": "Imports a Mermaid Mindmap",
-    "EXPORT_MAP": "Exports the map",
+    "IMPORT_MAP": "匯入地圖",
+    "IMPORT_MERMAID": "匯入Mermaid心智圖",
+    "IMPORT_JSON": "匯入JSON心智圖",
+    "EXPORT_MAP": "匯出地圖",
+    "EXPORT_JSON": "以JSON格式匯出地圖",
+    "EXPORT_SVG": "以SVG格式匯出地圖",
+    "EXPORT_PNG": "以PNG格式匯出地圖",
+    "EXPORT_JPEG": "以JPEG格式匯出地圖",
+    "EXPORT_PDF": "以PDF格式匯出地圖",
     "ESC": "關閉對話窗口",
     "FULLSCREEN": "將應用程式全螢幕",
     "CLOSE_MENU": "關閉選單",
@@ -38,6 +44,7 @@
     "EDIT_NODE": "編輯選取的節點文字",
     "COUPLE_NODE": "鎖定選取的節點",
     "NODE_IMAGE": "新增圖片於當前節點",
+    "NODE_IMAGE_REMOVE": "從節點中移除圖片",
     "PICTOGRAM": "Pictrogram",
     "START_EDIT_NODE": "Edit node text",
     "BOLD_TEXT": "將文字變成粗體",
@@ -70,7 +77,8 @@
     "FONT_MAX_SIZE": "Maximal font size",
     "FONT_INCREMENT": "Font size step",
     "FONT_INCREASE": "Increase font ",
-    "FONT_DECREASE": "Decrease font"
+    "FONT_DECREASE": "Decrease font",
+    "INFO": "打開資訊畫面"
   },
   "MODALS": {
     "GENERAL": {

--- a/teammapper-frontend/src/assets/i18n/zh-tw.json
+++ b/teammapper-frontend/src/assets/i18n/zh-tw.json
@@ -15,6 +15,7 @@
     "IMPORT_JSON": "匯入JSON心智圖",
     "EXPORT_MAP": "匯出地圖",
     "EXPORT_JSON": "以JSON格式匯出地圖",
+    "EXPORT_MERMAID": "以Mermaid格式匯出地圖", 
     "EXPORT_SVG": "以SVG格式匯出地圖",
     "EXPORT_PNG": "以PNG格式匯出地圖",
     "EXPORT_JPEG": "以JPEG格式匯出地圖",


### PR DESCRIPTION
Closes [#700](https://github.com/b310-digital/teammapper/issues/700) and adds a few tooltips to the toolbar buttons